### PR TITLE
fix: use torch device class instead of string for compatibility with comfy memory management

### DIFF
--- a/nodes/models/flux.py
+++ b/nodes/models/flux.py
@@ -260,7 +260,7 @@ class NunchakuFluxDiTLoader:
         data_type: str,
         **kwargs,
     ) -> tuple[FluxTransformer2DModel]:
-        device = f"cuda:{device_id}"
+        device = torch.device(f"cuda:{device_id}")
         prefixes = folder_paths.folder_names_and_paths["diffusion_models"][0]
         for prefix in prefixes:
             if os.path.exists(os.path.join(prefix, model_path)):


### PR DESCRIPTION
The `comfy.model_management.free_memory` function expects the `device` param to be a `<class 'torch.device'>`. Currently [this equality check](https://github.com/comfyanonymous/ComfyUI/blob/30b2eb8a93ce931f7b8e15f9f7dbc7bf751b1c17/comfy/model_management.py#L524) fails because it's comparing a `<class 'torch.device'>` with a `str`.

This proposed change fixes one class of OOM on my laptop's 8GB RTX 2070 GPU.

I think there is at least one other change needed to play nice with Comfy's memory management on low-VRAM GPUs. I think the main one is related to:

* https://github.com/mit-han-lab/nunchaku/issues/370

because the [model.detach call here](https://github.com/comfyanonymous/ComfyUI/blob/30b2eb8a93ce931f7b8e15f9f7dbc7bf751b1c17/comfy/model_management.py#L466) doesn't seem to work. If I can work that out I'll propose that change in separate pull request.