### PR TITLE
Fix deprecated shape warning by removing batch dimension from img_ids

### DIFF
--- a/wrappers/flux.py
+++ b/wrappers/flux.py
@@ -160,6 +160,12 @@ class ComfyFluxWrapper(nn.Module):
             self._prev_timestep = timestep_float
             with cache_context(self._cache_context):
                 if self.customized_forward is None:
+                    # Patch: remove batch dimension if present
+                    if img_ids.dim() == 3 and img_ids.size(0) == 1:
+                        img_ids = img_ids.squeeze(0)
+                    if txt_ids.dim() == 3 and txt_ids.size(0) == 1:
+                        txt_ids = txt_ids.squeeze(0)
+
                     out = model(
                         hidden_states=img,
                         encoder_hidden_states=context,
@@ -187,6 +193,12 @@ class ComfyFluxWrapper(nn.Module):
                     ).sample
         else:
             if self.customized_forward is None:
+                # Patch: remove batch dimension if present
+                if img_ids.dim() == 3 and img_ids.size(0) == 1:
+                    img_ids = img_ids.squeeze(0)
+                if txt_ids.dim() == 3 and txt_ids.size(0) == 1:
+                    txt_ids = txt_ids.squeeze(0)
+
                 out = model(
                     hidden_states=img,
                     encoder_hidden_states=context,


### PR DESCRIPTION
… and txt_ids

> Passing `txt_ids` 3d torch.Tensor is deprecated. Please remove the batch dimension and pass it as a 2d torch Tensor Passing `img_ids` 3d torch.Tensor is deprecated. Please remove the batch dimension and pass it as a 2d torch Tensor

In wrappers/flux.py, insert a small patch before each call to the model: 

# Patch: remove batch dimension if present

```
if img_ids.dim() == 3 and img_ids.size(0) == 1:
    img_ids = img_ids.squeeze(0)
if txt_ids.dim() == 3 and txt_ids.size(0) == 1:
    txt_ids = txt_ids.squeeze(0)
```

- Removes warnings
- Ensures future compatibility
