### PR TITLE
Fix crash when broken symlinks exist in diffusion_models folder

### DIFF
--- a/nodes/models/flux.py
+++ b/nodes/models/flux.py
@@ -96,7 +96,9 @@ class NunchakuFluxDiTLoader:
         # exclude the safetensors in the legacy svdquant folders
         new_safetensor_files = []
         for safetensor_file in safetensor_files:
-            safetensor_path = folder_paths.get_full_path_or_raise("diffusion_models", safetensor_file)
+            safetensor_path = folder_paths.get_full_path("diffusion_models", safetensor_file)
+            if safetensor_path is None:
+                continue  # Skip broken symlinks and missing files
             safetensor_path = Path(safetensor_path)
             if not (safetensor_path.parent / "config.json").exists():
                 new_safetensor_files.append(safetensor_file)


### PR DESCRIPTION
## Problem

The `NunchakuFluxDiTLoader` node crashes during initialization when broken symbolic links exist in the `models/diffusion_models/` folder, preventing ComfyUI from loading.

**Error:**
```
FileNotFoundError: Model in folder 'diffusion_models' with filename 'xxx.safetensors' not found.
```

## Root Cause

In `nodes/models/flux.py` line 99, `INPUT_TYPES()` uses `folder_paths.get_full_path_or_raise()` which throws an exception when encountering broken symlinks or missing files during the model list scan.

## Solution

Replace `get_full_path_or_raise()` with `get_full_path()` and skip `None` results (broken symlinks/missing files) instead of crashing.

## Changes

- Changed `folder_paths.get_full_path_or_raise()` → `folder_paths.get_full_path()`
- Added `if safetensor_path is None: continue` to skip invalid paths
- Node now loads successfully even with broken symlinks present

## Testing

Tested with broken symlinks in `models/diffusion_models/` - node now loads without errors and properly skips invalid files.