### PR TITLE
1.0.1 fix

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -82,4 +82,4 @@ def get_plugin_version() -> str:
         return project_version
 
 
-supported_versions = ["v1.0.0"]
+supported_versions = ["v1.0.0", "v1.0.1"]


### PR DESCRIPTION
currently the 1.0.1 version has an error due to a security check. the version number was forgotten in the supported list. So at the moment 1.0.1 is broken for users :(
this PR fixes https://github.com/nunchaku-tech/nunchaku/issues/755   #664 and #648 (possibly others)

This issue is fixed on the dev Branch but for current users it would be great to have a hotfix to get the plugin working.

@lmxyy please accept my humble offering