### PR TITLE
fix: ensure contiguous tensors after slicing in QwenImage attention

### DIFF
--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -316,8 +316,8 @@ class Attention(nn.Module):
         )
 
         # Split results back to separate streams
-        txt_attn_output = joint_hidden_states[:, :seq_txt, :]
-        img_attn_output = joint_hidden_states[:, seq_txt:, :]
+        txt_attn_output = joint_hidden_states[:, :seq_txt, :].contiguous()
+        img_attn_output = joint_hidden_states[:, seq_txt:, :].contiguous()
 
         img_attn_output = self.to_out[0](img_attn_output)
         img_attn_output = self.to_out[1](img_attn_output)


### PR DESCRIPTION
## Summary

Fixes sporadic `RuntimeError: view size is not compatible with input tensor's size and stride` that persists even after PR nunchaku-tech/nunchaku#673.

## The Problem

Even with PR #673's fix (changing `.view()` to `.reshape()` in `linear.py`), users still experience sporadic crashes with the same error. The issue occurs when:

1. `joint_hidden_states` is sliced along the sequence dimension in `qwenimage.py:319-320`
2. These slicing operations create non-contiguous tensor views
3. Despite `.reshape()` theoretically handling non-contiguous tensors, certain stride patterns still cause failures

This explains why:
- The error is sporadic (depends on memory layout from prior operations)
- Only rebooting fixes it (clears GPU memory fragmentation)

## The Fix

Add `.contiguous()` immediately after slicing operations to ensure tensors are copied to contiguous memory before being passed to nunchaku linear layers.

```python
# Before
txt_attn_output = joint_hidden_states[:, :seq_txt, :]
img_attn_output = joint_hidden_states[:, seq_txt:, :]

# After
txt_attn_output = joint_hidden_states[:, :seq_txt, :].contiguous()
img_attn_output = joint_hidden_states[:, seq_txt:, :].contiguous()
```

## Environment
- PyTorch 2.8.0+cu129
- ComfyUI 0.3.68

## Questions for Maintainers

Why does `.reshape()` in `linear.py:182` still fail despite being designed to handle non-contiguous tensors? Is there:
- A PyTorch 2.8 behavior change?
- A specific stride pattern that `.reshape()` can't handle?
- An issue in the nunchaku linear layer implementation?

This PR is defensive programming that prevents the crash, but the root cause may need investigation.

Closes #535