### PR TITLE
Support lazy-init Linear layers in Z-Image patching

### DIFF
--- a/models/zimage.py
+++ b/models/zimage.py
@@ -38,6 +38,35 @@ def add_comfy_cast_weights_attr(svdq_linear: SVDQW4A4Linear, comfy_linear: nn.Li
         svdq_linear.comfy_cast_weights = comfy_linear.comfy_cast_weights
         svdq_linear.weight = None
 
+def resolve_linear_dtype_device(
+    comfy_linear: nn.Linear,
+    torch_dtype: torch.dtype | None = None,
+    device: torch.device | str | None = None,
+) -> tuple[torch.dtype, torch.device | str]:
+    """
+    Resolve dtype/device from a possibly lazily initialized ComfyUI linear layer.
+
+    On recent Windows ComfyUI builds, manual-cast linears may be created with
+    `weight=None` until the state dict is loaded.
+    """
+    weight = getattr(comfy_linear, "weight", None)
+    bias = getattr(comfy_linear, "bias", None)
+
+    if torch_dtype is None:
+        if weight is not None:
+            torch_dtype = weight.dtype
+        else:
+            torch_dtype = getattr(comfy_linear, "weight_comfy_model_dtype", torch.bfloat16)
+
+    if device is None:
+        if weight is not None:
+            device = weight.device
+        elif bias is not None:
+            device = bias.device
+        else:
+            device = torch.device("cpu")
+
+    return torch_dtype, device
 
 def fuse_to_svdquant_linear(comfy_linear1: nn.Linear, comfy_linear2: nn.Linear, **kwargs) -> SVDQW4A4Linear:
     """
@@ -59,13 +88,15 @@ def fuse_to_svdquant_linear(comfy_linear1: nn.Linear, comfy_linear2: nn.Linear, 
     """
     assert comfy_linear1.in_features == comfy_linear2.in_features
     assert comfy_linear1.bias is None and comfy_linear2.bias is None
-    torch_dtype = kwargs.pop("torch_dtype", comfy_linear1.weight.dtype)
+    torch_dtype = kwargs.pop("torch_dtype", None)
+    device = kwargs.pop("device", None)
+    torch_dtype, device = resolve_linear_dtype_device(comfy_linear1, torch_dtype=torch_dtype, device=device)
     svdq_linear = SVDQW4A4Linear(
         comfy_linear1.in_features,
         comfy_linear1.out_features + comfy_linear2.out_features,
         bias=False,
         torch_dtype=torch_dtype,
-        device=comfy_linear1.weight.device,
+        device=device,
         **kwargs,
     )
     add_comfy_cast_weights_attr(svdq_linear, comfy_linear1)

--- a/models/zimage.py
+++ b/models/zimage.py
@@ -38,6 +38,7 @@ def add_comfy_cast_weights_attr(svdq_linear: SVDQW4A4Linear, comfy_linear: nn.Li
         svdq_linear.comfy_cast_weights = comfy_linear.comfy_cast_weights
         svdq_linear.weight = None
 
+
 def resolve_linear_dtype_device(
     comfy_linear: nn.Linear,
     torch_dtype: torch.dtype | None = None,
@@ -67,6 +68,7 @@ def resolve_linear_dtype_device(
             device = torch.device("cpu")
 
     return torch_dtype, device
+
 
 def fuse_to_svdquant_linear(comfy_linear1: nn.Linear, comfy_linear2: nn.Linear, **kwargs) -> SVDQW4A4Linear:
     """


### PR DESCRIPTION
## Motivation

  On recent ComfyUI Windows builds, some `Linear` modules can be lazily initialized and temporarily have `weight=None`
  before model weights are fully loaded.

  In the Z-Image loading path, `ComfyUI-nunchaku` patches attention and feed-forward modules before weight loading
  completes. The current implementation assumes `linear.weight` is always available and directly accesses
  `linear.weight.dtype` and `linear.weight.device`, which can raise:

  `AttributeError: 'NoneType' object has no attribute 'dtype'`

  This PR makes the Z-Image patching path compatible with lazy-initialized `Linear` modules while preserving the
  existing behavior when real weights are already present.

  This PR is paired with the corresponding `nunchaku` PR:
  - `nunchaku`: `Support lazy-initialized Linear modules in SVDQW4A4Linear.from_linear`
  - Link: `<NUNCHAKU_PR_URL>`

  ## Modifications

  - Add a helper in `models/zimage.py` to resolve `dtype` and `device` from a possibly lazy-initialized `Linear` module.
  - Keep the existing behavior unchanged when `linear.weight` is available.
  - Fall back to the provided `torch_dtype`, or `weight_comfy_model_dtype`, and finally CPU when `linear.weight is
  None`.
  - Apply this logic to `fuse_to_svdquant_linear()` so the Z-Image feed-forward patching path no longer depends on
  `linear.weight.dtype` or `linear.weight.device` being immediately available.
  - Run `pre-commit` on `models/zimage.py`.

  No new workflow test case is added because this PR does not introduce a new workflow, model asset, custom node, or
  output behavior. It only makes the existing Z-Image patching path tolerant to lazy-initialized `Linear` modules.

  ## Checklist

  - [x] Code is formatted using Pre-Commit hooks (run `pre-commit run --all-files`).
  - [ ] Relevant unit tests are added in the [`tests/workflows`](../tests/workflows) directory following the guidance in
  the [Contribution Guide](https://nunchaku.tech/docs/comfyui-nunchaku/developer/contribution_guide.html).
  - [ ] Reference images are uploaded to PR comments and URLs are added to `test_cases.json`.
  - [ ] Additional test data (if needed) is registered in [`test_data/inputs.yaml`](../test_data/inputs.yaml).
  - [ ] Additional models (if needed) are registered in [`scripts/download_models.py`](../scripts/download_models.py)
  and [`test_data/models.yaml`](../test_data/models.yaml).
  - [ ] Additional custom nodes (if needed) are added to [`.github/workflows/pr-test.yaml`](../.github/workflows/pr-
  test.yaml).
  - [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please
  remove yourself as a co-author when merging.
  - [ ] Please feel free to join our [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://huggingface.co/
  datasets/nunchaku-tech/cdn/blob/main/nunchaku/assets/wechat.jpg) to discuss your PR.