### PR TITLE
feat: add NunchakuFlux2DiTLoader for FLUX.2-klein-9B-Nunchaku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-models/
-output/
-input/
-temp/
+/models/
+/output/
+/input/
+/temp/
 # Prerequisites
 *.d
 

--- a/__init__.py
+++ b/__init__.py
@@ -86,6 +86,13 @@ except ImportError:
     logger.exception("Node `NunchakuFluxDiTLoader` import failed:")
 
 try:
+    from .nodes.models.flux2 import NunchakuFlux2DiTLoader
+
+    NODE_CLASS_MAPPINGS["NunchakuFlux2DiTLoader"] = NunchakuFlux2DiTLoader
+except ImportError:
+    logger.exception("Node `NunchakuFlux2DiTLoader` import failed:")
+
+try:
     from .nodes.models.qwenimage import NunchakuQwenImageDiTLoader
 
     NODE_CLASS_MAPPINGS["NunchakuQwenImageDiTLoader"] = NunchakuQwenImageDiTLoader

--- a/nodes/models/configs/flux2-klein-9B.json
+++ b/nodes/models/configs/flux2-klein-9B.json
@@ -1,0 +1,23 @@
+{
+  "model_class": "Flux2",
+  "model_config": {
+    "image_model": "flux2",
+    "in_channels": 128,
+    "out_channels": 128,
+    "vec_in_dim": null,
+    "context_in_dim": 12288,
+    "hidden_size": 4096,
+    "mlp_ratio": 3.0,
+    "num_heads": 32,
+    "depth": 8,
+    "depth_single_blocks": 24,
+    "axes_dim": [32, 32, 32, 32],
+    "theta": 2000,
+    "patch_size": 1,
+    "qkv_bias": true,
+    "guidance_embed": false,
+    "txt_ids_dims": [1, 2],
+    "global_modulation": true,
+    "disable_unet_model_creation": true
+  }
+}

--- a/nodes/models/flux2.py
+++ b/nodes/models/flux2.py
@@ -1,0 +1,299 @@
+"""
+This module provides the :class:`NunchakuFlux2DiTLoader` class for loading Nunchaku FLUX.2 models
+(e.g. FLUX.2-klein-9B-Nunchaku).
+
+It mirrors the UX of NunchakuFluxDiTLoader but accounts for Flux2-specific differences:
+- NunchakuFlux2Transformer2DModel.from_pretrained does not support offload (raises NotImplementedError).
+- Attention is set via set_attention_backend instead of set_attention_impl.
+- No apply_cache_on_transformer adapter exists yet; we use the model's enable_cache API.
+- The model uses 4-axis RoPE (axes_dim typically [32,32,32,32]), global_modulation, no vector_in (y is unused),
+  and a different forward signature (no pooled_projections).
+"""
+
+import gc
+import json
+import logging
+import os
+
+import comfy.model_management
+import comfy.model_patcher
+import torch
+from comfy.supported_models import Flux2
+
+from nunchaku.models.transformers.transformer_flux2 import NunchakuFlux2Transformer2DModel
+from nunchaku.utils import is_turing
+
+from ...wrappers.flux2 import ComfyFlux2Wrapper
+from ..utils import get_filename_list, get_full_path_or_raise
+
+# Get log level from environment variable (default to INFO)
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+
+# Configure logging
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO), format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+class NunchakuFlux2DiTLoader:
+    """
+    Loader for Nunchaku FLUX.2 models (e.g. FLUX.2-klein-9B-Nunchaku).
+
+    This class manages model loading, device selection, attention backend selection,
+    and first-block caching. CPU offload is not supported by the underlying nunchaku Flux2 loader
+    and is therefore ignored (the model is always loaded directly to the target device).
+
+    Attributes
+    ----------
+    transformer : :class:`~nunchaku.models.transformers.transformer_flux2.NunchakuFlux2Transformer2DModel` or None
+        The loaded transformer model.
+    metadata : dict or None
+        Metadata associated with the loaded model (from safetensors).
+    model_path : str or None
+        Path to the loaded model.
+    device : torch.device or None
+        Device on which the model is loaded.
+    data_type : str or None
+        Data type used for inference.
+    patcher : object or None
+        ComfyUI model patcher instance.
+    """
+
+    def __init__(self):
+        """
+        Initialize the NunchakuFlux2DiTLoader.
+        """
+        self.transformer = None
+        self.metadata = None
+        self.model_path = None
+        self.device = None
+        self.data_type = None
+        self.patcher = None
+        self.device = comfy.model_management.get_torch_device()
+
+    @classmethod
+    def INPUT_TYPES(s):
+        """
+        Define the input types and tooltips for the node.
+
+        Returns
+        -------
+        dict
+            A dictionary specifying the required inputs and their descriptions for the node interface.
+        """
+        safetensor_files = get_filename_list("diffusion_models")
+
+        ngpus = torch.cuda.device_count()
+
+        all_turing = True
+        for i in range(torch.cuda.device_count()):
+            if not is_turing(f"cuda:{i}"):
+                all_turing = False
+
+        if all_turing:
+            attention_options = ["nunchaku-fp16"]  # turing GPUs do not support flashattn2
+            dtype_options = ["float16"]
+        else:
+            attention_options = ["nunchaku-fp16", "flashattn2"]
+            dtype_options = ["bfloat16", "float16"]
+
+        return {
+            "required": {
+                "model_path": (
+                    safetensor_files,
+                    {
+                        "tooltip": "The Nunchaku FLUX.2 safetensors file (e.g. flux2-klein-9B-nun-kv.safetensors). "
+                        "Only Nunchaku-quantized Flux2 models are supported."
+                    },
+                ),
+                "cache_threshold": (
+                    "FLOAT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 1,
+                        "step": 0.001,
+                        "tooltip": "First-block cache residual difference threshold. 0 disables caching. "
+                        "Higher values increase speed at the cost of potential quality loss.",
+                    },
+                ),
+                "attention": (
+                    attention_options,
+                    {
+                        "tooltip": "Attention implementation. 'nunchaku-fp16' can be faster on 30/40/50-series GPUs. "
+                        "'flashattn2' is the standard backend."
+                    },
+                ),
+                "data_type": (
+                    dtype_options,
+                    {
+                        "tooltip": "Data type for the transformer. bfloat16 is recommended on Ampere+ GPUs. "
+                        "float16 may be required on older GPUs."
+                    },
+                ),
+                "device_id": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": max(0, ngpus - 1),
+                        "tooltip": "CUDA device ID to use for this model.",
+                    },
+                ),
+            },
+            "optional": {},
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "load_model"
+    CATEGORY = "Nunchaku"
+    TITLE = "Nunchaku FLUX.2 DiT Loader"
+    OUTPUT_NODE = False
+
+    def load_model(self, model_path: str, cache_threshold: float, attention: str, data_type: str, device_id: int):
+        """
+        Load a Nunchaku FLUX.2 model and wrap it for ComfyUI.
+
+        Parameters
+        ----------
+        model_path : str
+            Filename (relative to ComfyUI's diffusion_models directory) of the Nunchaku Flux2 safetensors.
+        cache_threshold : float
+            Residual diff threshold for first-block cache (0 disables).
+        attention : str
+            Attention backend name ("nunchaku-fp16" or "flashattn2").
+        data_type : str
+            "bfloat16" or "float16".
+        device_id : int
+            CUDA device index.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the loaded and patched model (Comfy ModelPatcher wrapping a Flux2 model_base).
+        """
+        device = torch.device(f"cuda:{device_id}")
+
+        model_path = get_full_path_or_raise("diffusion_models", model_path)
+
+        if device_id >= torch.cuda.device_count():
+            raise ValueError(f"Invalid device_id: {device_id}. Only {torch.cuda.device_count()} GPUs available.")
+
+        gpu_properties = torch.cuda.get_device_properties(device_id)
+        gpu_memory = gpu_properties.total_memory / (1024**2)
+        gpu_name = gpu_properties.name
+        logger.debug(f"GPU {device_id} ({gpu_name}) Memory: {gpu_memory} MiB")
+
+        # NOTE: NunchakuFlux2Transformer2DModel.from_pretrained does not support offload.
+        # We always load directly to the target device. The UI option is omitted for this node.
+        cpu_offload_enabled = False
+
+        if (
+            self.model_path != model_path
+            or self.device != device
+            or self.data_type != data_type
+        ):
+            if self.transformer is not None:
+                model_size = comfy.model_management.module_size(self.transformer)
+                transformer = self.transformer
+                self.transformer = None
+                transformer.to("cpu")
+                del transformer
+                gc.collect()
+                comfy.model_management.cleanup_models_gc()
+                comfy.model_management.soft_empty_cache()
+                comfy.model_management.free_memory(model_size, device)
+
+            # from_pretrained for Flux2 nunchaku: no 'offload' argument (raises NotImplementedError if passed).
+            self.transformer, self.metadata = NunchakuFlux2Transformer2DModel.from_pretrained(
+                model_path,
+                device=device,
+                torch_dtype=torch.float16 if data_type == "float16" else torch.bfloat16,
+                return_metadata=True,
+            )
+            self.model_path = model_path
+            self.device = device
+            self.data_type = data_type
+
+        transformer = self.transformer
+
+        # Apply first-block cache if requested. Flux2 nunchaku exposes enable_cache directly.
+        if cache_threshold > 0:
+            try:
+                transformer.enable_cache(residual_diff_threshold=cache_threshold)
+                logger.debug(f"Enabled Flux2 cache with residual_diff_threshold={cache_threshold}")
+            except Exception as e:
+                logger.warning(f"Failed to enable cache on NunchakuFlux2Transformer2DModel: {e}")
+        else:
+            try:
+                if getattr(transformer, "is_cache_enabled", None) and transformer.is_cache_enabled():
+                    transformer.disable_cache()
+            except Exception:
+                pass
+
+        # Set attention backend (Flux2 uses set_attention_backend, not set_attention_impl).
+        try:
+            if attention == "nunchaku-fp16":
+                transformer.set_attention_backend("nunchaku-fp16")
+            else:
+                transformer.set_attention_backend("flashattn2")
+        except Exception as e:
+            logger.warning(f"Failed to set attention backend '{attention}': {e}")
+
+        # Resolve comfy_config (metadata or fallback file).
+        if self.metadata is None:
+            comfy_config = None
+        else:
+            comfy_config_str = self.metadata.get("comfy_config", None)
+            if comfy_config_str:
+                try:
+                    comfy_config = json.loads(comfy_config_str)
+                except Exception:
+                    comfy_config = None
+            else:
+                comfy_config = None
+
+        if not comfy_config or "model_config" not in comfy_config:
+            # Fallback to a config file next to this module.
+            default_config_root = os.path.join(os.path.dirname(__file__), "configs")
+            base = os.path.basename(model_path)
+            # Strip common nunchaku / quantization prefixes and suffixes so "flux2-klein-9B-nun-kv.safetensors"
+            # can resolve to "flux2-klein-9B.json".
+            for token in ["svdq-int4-", "svdq-fp4-", "svdq-", "-nun-kv", "-nun", ".safetensors"]:
+                base = base.replace(token, "")
+            config_path = os.path.join(default_config_root, f"{base}.json")
+            if not os.path.exists(config_path):
+                config_path = os.path.join(default_config_root, "flux2-klein-9B.json")
+            if not os.path.exists(config_path):
+                raise FileNotFoundError(
+                    f"ComfyUI model config not found in metadata and no fallback config at {config_path}. "
+                    "Please provide a 'comfy_config' entry in the safetensors metadata or add a config JSON."
+                )
+            logger.info(f"Loading ComfyUI model config from {config_path}")
+            comfy_config = json.load(open(config_path, "r"))
+
+        model_config_dict = comfy_config.get("model_config", {}).copy()
+        if "disable_unet_model_creation" not in model_config_dict:
+            model_config_dict["disable_unet_model_creation"] = True
+
+        model_class_name = comfy_config.get("model_class", "Flux2")
+        if model_class_name != "Flux2":
+            logger.warning(f"Unexpected model_class '{model_class_name}' for Flux2 loader; proceeding with Flux2.")
+
+        model_config = Flux2(model_config_dict)
+        model_config.set_inference_dtype(torch.bfloat16, None)
+        model_config.custom_operations = None
+
+        model = model_config.get_model({})
+        model.diffusion_model = ComfyFlux2Wrapper(
+            transformer,
+            config=model_config_dict,
+            ctx_for_copy={
+                "comfy_config": comfy_config,
+                "model_config": model_config,
+                "device": device,
+                "device_id": device_id,
+            },
+        )
+
+        model = comfy.model_patcher.ModelPatcher(model, device, device_id)
+        return (model,)

--- a/wrappers/flux2.py
+++ b/wrappers/flux2.py
@@ -1,0 +1,336 @@
+"""
+This module provides a wrapper for the :class:`~nunchaku.models.transformers.transformer_flux2.NunchakuFlux2Transformer2DModel`,
+enabling integration with ComfyUI forward, reference latents, and first-block caching.
+"""
+
+from typing import Callable
+
+import torch
+from comfy.ldm.common_dit import pad_to_patch_size
+from einops import rearrange, repeat
+from torch import nn
+
+from nunchaku.models.transformers.transformer_flux2 import NunchakuFlux2Transformer2DModel
+
+try:
+    from nunchaku.caching.fbcache import cache_context, create_cache_context
+except Exception:
+    cache_context = None
+    create_cache_context = None
+
+
+class ComfyFlux2Wrapper(nn.Module):
+    """
+    Wrapper for :class:`~nunchaku.models.transformers.transformer_flux2.NunchakuFlux2Transformer2DModel`
+    to support ComfyUI workflows, reference latents, and caching.
+
+    Parameters
+    ----------
+    model : :class:`~nunchaku.models.transformers.transformer_flux2.NunchakuFlux2Transformer2DModel`
+        The underlying Nunchaku Flux2 model to wrap.
+    config : dict
+        Model configuration dictionary (the inner "model_config" from comfy_config).
+    customized_forward : Callable, optional
+        Optional custom forward function.
+    forward_kwargs : dict, optional
+        Additional keyword arguments for the forward pass.
+    ctx_for_copy : dict
+        A dict that holds initialization context for later duplication of this wrapper.
+
+    Attributes
+    ----------
+    model : :class:`~nunchaku.models.transformers.transformer_flux2.NunchakuFlux2Transformer2DModel`
+        The wrapped model.
+    dtype : torch.dtype
+        Data type of the model parameters.
+    config : dict
+        Model configuration.
+    loras : list
+        List of LoRA metadata (currently unused for Flux2; kept for API compatibility).
+    customized_forward : Callable or None
+        Custom forward function if provided.
+    forward_kwargs : dict
+        Additional arguments for the forward pass.
+    ctx_for_copy : dict
+        Context for duplication.
+    """
+
+    def __init__(
+        self,
+        model: NunchakuFlux2Transformer2DModel,
+        config: dict,
+        customized_forward: Callable = None,
+        forward_kwargs: dict | None = None,
+        ctx_for_copy: dict | None = None,
+    ):
+        super(ComfyFlux2Wrapper, self).__init__()
+        self.model = model
+        self.dtype = next(model.parameters()).dtype
+        self.config = config if config is not None else {}
+        self.loras = []
+
+        self.customized_forward = customized_forward
+        self.forward_kwargs = {} if forward_kwargs is None else forward_kwargs
+        self.ctx_for_copy = (ctx_for_copy or {}).copy()
+
+        self._prev_timestep = None
+        self._cache_context = None
+
+    def process_img(self, x, index=0, h_offset=0, w_offset=0, transformer_options=None):
+        """
+        Preprocess an input latent tensor for the Flux2 model.
+
+        Pads (if needed) and rearranges the latent into tokens and generates corresponding image IDs
+        using the configured number of axes (typically 4 for Flux2 Klein).
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input latent tensor of shape (batch, channels, height, width). For Flux2 this is usually 128 channels.
+        index : int, optional
+            Index for image ID encoding (used for reference latents).
+        h_offset : int, optional
+            Height offset for patch IDs.
+        w_offset : int, optional
+            Width offset for patch IDs.
+        transformer_options : dict, optional
+            Comfy transformer options (may contain rope_options for advanced positioning).
+
+        Returns
+        -------
+        img : torch.Tensor
+            Rearranged latent tensor of shape (batch, num_tokens, channels).
+        img_ids : torch.Tensor
+            Image ID tensor of shape (batch, num_tokens, num_axes).
+        """
+        if transformer_options is None:
+            transformer_options = {}
+
+        bs, c, h, w = x.shape
+        patch_size = self.config.get("patch_size", 1)
+        x = pad_to_patch_size(x, (patch_size, patch_size))
+
+        img = rearrange(x, "b c (h ph) (w pw) -> b (h w) (c ph pw)", ph=patch_size, pw=patch_size)
+        h_len = (h + (patch_size // 2)) // patch_size
+        w_len = (w + (patch_size // 2)) // patch_size
+
+        h_offset = (h_offset + (patch_size // 2)) // patch_size
+        w_offset = (w_offset + (patch_size // 2)) // patch_size
+
+        steps_h = h_len
+        steps_w = w_len
+
+        rope_options = transformer_options.get("rope_options", None)
+        if rope_options is not None:
+            h_len = (h_len - 1.0) * rope_options.get("scale_y", 1.0) + 1.0
+            w_len = (w_len - 1.0) * rope_options.get("scale_x", 1.0) + 1.0
+
+            index += rope_options.get("shift_t", 0.0)
+            h_offset += rope_options.get("shift_y", 0.0)
+            w_offset += rope_options.get("shift_x", 0.0)
+
+        axes_dim = self.config.get("axes_dim", [32, 32, 32, 32])
+        num_axes = len(axes_dim)
+
+        img_ids = torch.zeros((steps_h, steps_w, num_axes), device=x.device, dtype=torch.float32)
+        # Comfy's Flux (incl. Flux2) only populates the first 3 axes even when len(axes_dim) == 4.
+        # The 4th axis (if present) stays at 0.
+        img_ids[:, :, 0] = img_ids[:, :, 1] + index
+        img_ids[:, :, 1] = img_ids[:, :, 1] + torch.linspace(
+            h_offset, h_len - 1 + h_offset, steps=steps_h, device=x.device, dtype=torch.float32
+        ).unsqueeze(1)
+        img_ids[:, :, 2] = img_ids[:, :, 2] + torch.linspace(
+            w_offset, w_len - 1 + w_offset, steps=steps_w, device=x.device, dtype=torch.float32
+        ).unsqueeze(0)
+        # axes 3+ (if any) remain zero
+
+        return img, repeat(img_ids, "h w c -> b (h w) c", b=bs)
+
+    def forward(
+        self,
+        x,
+        timestep,
+        context,
+        y=None,
+        guidance=None,
+        ref_latents=None,
+        control=None,
+        transformer_options=None,
+        **kwargs,
+    ):
+        """
+        Forward pass for the wrapped Flux2 model.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input latent tensor (B, C, H, W). C is typically 128 for Flux2.
+        timestep : float or torch.Tensor
+            Diffusion timestep.
+        context : torch.Tensor
+            Text encoder hidden states (B, seq_len, context_in_dim), e.g. 12288 for Klein.
+        y : torch.Tensor or None
+            Pooled projections / ADM. Not used by Flux2 Klein (vec_in_dim=None); accepted for API compatibility.
+        guidance : torch.Tensor or float or None
+            Guidance value. Klein has guidance_embeds=False, but we still forward it if provided.
+        ref_latents : list[torch.Tensor] or None
+            Optional reference latents for img2img / reference workflows.
+        control : dict or None
+            ControlNet samples (input/output). Currently ignored for Flux2 nunchaku (no controlnet injection in forward).
+        transformer_options : dict, optional
+            ComfyUI transformer options (patches, rope_options, etc.).
+        **kwargs
+            Additional keyword arguments (e.g. ref_latents_method).
+
+        Returns
+        -------
+        torch.Tensor
+            Output latent tensor of shape (B, out_channels, H, W) matching the input spatial size.
+        """
+        if transformer_options is None:
+            transformer_options = {}
+
+        if isinstance(timestep, torch.Tensor):
+            if timestep.numel() == 1:
+                timestep_float = timestep.item()
+            else:
+                timestep_float = timestep.flatten()[0].item()
+        else:
+            assert isinstance(timestep, float)
+            timestep_float = timestep
+
+        model = self.model
+        assert isinstance(model, NunchakuFlux2Transformer2DModel)
+
+        bs, c, h_orig, w_orig = x.shape
+        patch_size = self.config.get("patch_size", 1)
+        h_len = (h_orig + (patch_size // 2)) // patch_size
+        w_len = (w_orig + (patch_size // 2)) // patch_size
+
+        img, img_ids = self.process_img(x, transformer_options=transformer_options)
+        img_tokens = img.shape[1]
+
+        # Reference latents (simplified handling, mirroring the Flux1 nunchaku wrapper approach)
+        if ref_latents is not None:
+            h = 0
+            w = 0
+            for ref in ref_latents:
+                h_offset = 0
+                w_offset = 0
+                if ref.shape[-2] + h > ref.shape[-1] + w:
+                    w_offset = w
+                else:
+                    h_offset = h
+
+                kontext, kontext_ids = self.process_img(
+                    ref, index=1, h_offset=h_offset, w_offset=w_offset, transformer_options=transformer_options
+                )
+                img = torch.cat([img, kontext], dim=1)
+                img_ids = torch.cat([img_ids, kontext_ids], dim=1)
+                h = max(h, ref.shape[-2] + h_offset)
+                w = max(w, ref.shape[-1] + w_offset)
+
+        axes_dim = self.config.get("axes_dim", [32, 32, 32, 32])
+        num_axes = len(axes_dim)
+        txt_ids = torch.zeros((bs, context.shape[1], num_axes), device=x.device, dtype=torch.float32)
+
+        # LoRA composition: currently disabled in nunchaku for Flux2 (SVDQLoRAMixin not present).
+        # We keep the slot for future compatibility but do nothing if loras are supplied.
+        if self.loras:
+            # Placeholder: if future nunchaku Flux2 builds support LoRA, implement compose + update_lora_params here.
+            pass
+
+        # ControlNet: Flux2 nunchaku forward does not currently expose controlnet_block_samples.
+        # We accept the argument for compatibility but do not inject.
+        if control is not None:
+            # Future: if supported, map control["input"] / control["output"] into the call.
+            pass
+
+        # Caching (first-block cache via nunchaku's cache_context when enabled on the model)
+        use_cache = False
+        try:
+            if getattr(model, "is_cache_enabled", None) is not None:
+                use_cache = bool(model.is_cache_enabled())
+            elif getattr(model, "_is_cached", False):
+                use_cache = True
+        except Exception:
+            use_cache = False
+
+        if cache_context is not None and (use_cache or getattr(model, "residual_diff_threshold_multi", 0)):
+            cache_invalid = False
+            if self._prev_timestep is None:
+                cache_invalid = True
+            elif self._prev_timestep < timestep_float + 1e-5:
+                cache_invalid = True
+
+            if cache_invalid or self._cache_context is None:
+                self._cache_context = create_cache_context()
+
+            self._prev_timestep = timestep_float
+            with cache_context(self._cache_context):
+                if self.customized_forward is None:
+                    out = model(
+                        hidden_states=img,
+                        encoder_hidden_states=context,
+                        timestep=timestep,
+                        img_ids=img_ids,
+                        txt_ids=txt_ids,
+                        guidance=guidance if self.config.get("guidance_embed") else None,
+                        **self.forward_kwargs,
+                    ).sample
+                else:
+                    out = self.customized_forward(
+                        model,
+                        hidden_states=img,
+                        encoder_hidden_states=context,
+                        timestep=timestep,
+                        img_ids=img_ids,
+                        txt_ids=txt_ids,
+                        guidance=guidance if self.config.get("guidance_embed") else None,
+                        **self.forward_kwargs,
+                    ).sample
+        else:
+            if self.customized_forward is None:
+                out = model(
+                    hidden_states=img,
+                    encoder_hidden_states=context,
+                    timestep=timestep,
+                    img_ids=img_ids,
+                    txt_ids=txt_ids,
+                    guidance=guidance if self.config.get("guidance_embed") else None,
+                    **self.forward_kwargs,
+                ).sample
+            else:
+                out = self.customized_forward(
+                    model,
+                    hidden_states=img,
+                    encoder_hidden_states=context,
+                    timestep=timestep,
+                    img_ids=img_ids,
+                    txt_ids=txt_ids,
+                    guidance=guidance if self.config.get("guidance_embed") else None,
+                    **self.forward_kwargs,
+                ).sample
+
+        # The nunchaku Flux2 model returns a diffusers-like object with .sample of shape (B, T, C)
+        # We need to reshape back to (B, out_channels, H, W) using the original spatial size.
+        # For patch_size=1 and out_channels=128 this is straightforward.
+        out_channels = self.config.get("out_channels", 128)
+        # out shape from model: (B, num_tokens_total, patch_size*patch_size*out_channels)
+        # For ref_latents we concatenated extra tokens; we only want the first img_tokens for the main image.
+        out = out[:, :img_tokens, :]
+        ps = patch_size
+        h_len = (h_orig + (ps // 2)) // ps
+        w_len = (w_orig + (ps // 2)) // ps
+        out = rearrange(
+            out,
+            "b (h w) (c ph pw) -> b c (h ph) (w pw)",
+            h=h_len,
+            w=w_len,
+            ph=ps,
+            pw=ps,
+            c=out_channels,
+        )
+        # Crop to original size if padding was added
+        out = out[:, :, :h_orig, :w_orig]
+        return out


### PR DESCRIPTION
- New node "Nunchaku FLUX.2 DiT Loader" (mirrors Flux1 loader UX)
- ComfyFlux2Wrapper for correct 4-axis RoPE, ref_latents, FBCache, and forward signature (no pooled_projections)
- Fallback config nodes/models/configs/flux2-klein-9B.json (metadata "comfy_config" is empty for this model)
- Registration in __init__.py
- .gitignore fix: anchor models/ rule so nodes/models/ sources are trackable

Tested end-to-end loading of flux/2/flux2-klein-9B-nun-kv.safetensors inside ComfyUI custom node context.

<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](https://nunchaku.tech/docs/ComfyUI-nunchaku/developer/contribution_guide.html) for more details. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Code is formatted using Pre-Commit hooks (run `pre-commit run --all-files`).
- [ ] Relevant unit tests are added in the [`tests/workflows`](../tests/workflows) directory following the guidance in the [Contribution Guide](https://nunchaku.tech/docs/comfyui-nunchaku/developer/contribution_guide.html).
- [ ] Reference images are uploaded to PR comments and URLs are added to `test_cases.json`.
- [ ] Additional test data (if needed) is registered in [`test_data/inputs.yaml`](../test_data/inputs.yaml).
- [ ] Additional models (if needed) are registered in [`scripts/download_models.py`](../scripts/download_models.py) and [`test_data/models.yaml`](../test_data/models.yaml).
- [ ] Additional custom nodes (if needed) are added to [`.github/workflows/pr-test.yaml`](../.github/workflows/pr-test.yaml).
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://huggingface.co/datasets/nunchaku-tech/cdn/blob/main/nunchaku/assets/wechat.jpg) to discuss your PR.
